### PR TITLE
cleaned up style to be more pythonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lo
 *.la
 *~
+*.pyc
 
 autoCrop
 autoCropScribe

--- a/test_scribe.py
+++ b/test_scribe.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+
+"""
+    scribe_test
+    ~~~~~~~~~~~
+
+    basic test cases for processScribe
+"""
+
+from lxml import etree
+from StringIO import StringIO
+import unittest
+import processScribe as ps
+
+XML = {'rmtag': "<parent><child>1</child><child>2</child></parent>"}       
+
+class TestScribe(unittest.TestCase):
+
+    def test_crop_score(self):
+        crop_score = ps.score(4, 2, 1)
+        self.assertTrue(crop_score == 3.0,
+                        "Expected crop_score to return 3.0, not %s" % crop_score)


### PR DESCRIPTION
Going through my old changeset and incrementally making small changes (since I don't have test data yet)
- As for PEP8, removed comparisons of None via == or !=, use 'is' or 'is not' instead
- Use try/except or raise instead of assert as, when running python with -O, any validation that relies on assert will disappear
- Renamed id to id_ to avoid overriding python builtin id()
